### PR TITLE
마이 페이지 - 내 답변(히스토리) API 연동 및 메인 페이지 수정

### DIFF
--- a/src/app/api/users/history/route.ts
+++ b/src/app/api/users/history/route.ts
@@ -1,0 +1,18 @@
+import { NextRequest, NextResponse } from "next/server";
+import { GetUserAnswersUsecase } from "@/application/user/GetUserAnswerUsecase";
+import { SbUserRepository } from "@/infra/repositories/supabase/SbUserRepository";
+
+const usecase = new GetUserAnswersUsecase(new SbUserRepository());
+
+export async function GET(request: NextRequest) {
+  const email = request.nextUrl.searchParams.get("email");
+  if (!email) return NextResponse.json({ error: "이메일이 필요합니다." }, { status: 400 });
+
+  try {
+    const answers = await usecase.execute(email);
+    return NextResponse.json(answers, { status: 200 });
+  } catch (error) {
+    console.error("답변 조회 실패:", error);
+    return NextResponse.json({ error: "답변 정보를 불러오지 못했습니다." }, { status: 500 });
+  }
+}

--- a/src/app/components/CategoryList.tsx
+++ b/src/app/components/CategoryList.tsx
@@ -2,22 +2,22 @@ import Image from "next/image";
 import Link from "next/link";
 
 const category = [
-  { id: 1, name: "HTML", src: "/assets/images/category/1.svg", href: "/questions?category=1" },
-  { id: 2, name: "CSS", src: "/assets/images/category/2.svg", href: "/questions?category=2" },
+  { id: 1, name: "HTML", src: "/assets/images/category/1.svg", href: "/questions?categoryId=1" },
+  { id: 2, name: "CSS", src: "/assets/images/category/2.svg", href: "/questions?categoryId=2" },
   {
     id: 3,
     name: "JavaScript",
     src: "/assets/images/category/3.svg",
-    href: "/questions?category=3",
+    href: "/questions?categoryId=3",
   },
   {
     id: 4,
     name: "TypeScript",
     src: "/assets/images/category/4.svg",
-    href: "/questions?category=4",
+    href: "/questions?categoryId=4",
   },
-  { id: 5, name: "React", src: "/assets/images/category/5.svg", href: "/questions?category=5" },
-  { id: 6, name: "Next", src: "/assets/images/category/6.svg", href: "/questions?category=6" },
+  { id: 5, name: "React", src: "/assets/images/category/5.svg", href: "/questions?categoryId=5" },
+  { id: 6, name: "Next", src: "/assets/images/category/6.svg", href: "/questions?categoryId=6" },
 ];
 
 export default function CategoryList() {

--- a/src/app/users/components/MyAnswer.tsx
+++ b/src/app/users/components/MyAnswer.tsx
@@ -8,14 +8,16 @@ import { Heart } from "lucide-react";
 import { useAuthStore } from "@/store/useAuthStore";
 import { Skeleton } from "@/components/ui/skeleton";
 import { Pagination } from "@/components/ui/pagination";
+import Link from "next/link";
 
-type UserAnswer = {
+interface UserAnswer {
+  questionId: number;
   categoryName: string;
   questionTitle: string;
   answerContent: string;
   createdAt: string;
   likeCount: number;
-};
+}
 
 export default function MyAnswerPage() {
   const { user } = useAuthStore();
@@ -41,6 +43,7 @@ export default function MyAnswerPage() {
       setMyAnswers(data);
       setIsLoading(false);
     };
+
     fetchAnswers();
   }, [user?.email]);
 
@@ -64,24 +67,26 @@ export default function MyAnswerPage() {
   return (
     <div className="flex flex-col gap-[var(--space-24)] mb-[100px]">
       {paginatedAnswers.map((answer, index) => (
-        <Card key={index} variant="default">
-          <div className="flex items-center gap-4 mb-4">
-            <Badge variant="default">{answer.categoryName}</Badge>
-            <p className="txt-2xl-b line-clamp-1">{answer.questionTitle}</p>
-          </div>
-          <div className="flex flex-col gap-[var(--space-40)]">
-            <p className="line-clamp-2">{answer.answerContent}</p>
-            <div className="flex justify-between items-center">
-              <p className="txt-sm !text-[var(--gray-02)]">
-                {new Date(answer.createdAt).toLocaleDateString("ko-KR")}
-              </p>
-              <div className="flex items-center gap-2 txt-sm !text-[var(--gray-02)]">
-                <Heart className="w-4 h-4 fill-[var(--black)] stroke-none" />
-                <p>{formatNumber(answer.likeCount)}</p>
+        <Link href={`/questions/${answer.questionId}`} key={index}>
+          <Card variant="default">
+            <div className="flex items-center gap-4 mb-4">
+              <Badge variant="default">{answer.categoryName}</Badge>
+              <p className="txt-2xl-b line-clamp-1">{answer.questionTitle}</p>
+            </div>
+            <div className="flex flex-col gap-[var(--space-40)]">
+              <p className="line-clamp-2">{answer.answerContent}</p>
+              <div className="flex justify-between items-center">
+                <p className="txt-sm !text-[var(--gray-02)]">
+                  {new Date(answer.createdAt).toLocaleDateString("ko-KR")}
+                </p>
+                <div className="flex items-center gap-2 txt-sm !text-[var(--gray-02)]">
+                  <Heart className="w-4 h-4 fill-[var(--black)] stroke-none" />
+                  <p>{formatNumber(answer.likeCount)}</p>
+                </div>
               </div>
             </div>
-          </div>
-        </Card>
+          </Card>
+        </Link>
       ))}
 
       <Pagination

--- a/src/app/users/components/MyAnswer.tsx
+++ b/src/app/users/components/MyAnswer.tsx
@@ -1,54 +1,97 @@
 "use client";
 
+import { useEffect, useState } from "react";
 import { Badge } from "@/components/ui/badge";
 import { Card } from "@/components/ui/card";
 import { formatNumber } from "@/utils/handleFormat";
 import { Heart } from "lucide-react";
+import { useAuthStore } from "@/store/useAuthStore";
+import { Skeleton } from "@/components/ui/skeleton";
+import { Pagination } from "@/components/ui/pagination";
 
-// 실제 데이터로 매핑 필요
-const myAnswers = [
-  {
-    id: 1,
-    category: "JavaScript",
-    title:
-      "HTTP 메소드에 대한 설명HTTP 메소드에 대한 설명HTTP 메소드에 대한 설명HTTP 메소드에 대한 설명",
-    content:
-      "Next.js는 버전 13부터 React 18에서 도입된 서버 컴포넌트를 지원하고 있습니다. 시간이 흐르면서 많은 분이 이를 익숙하게 활용하고 있지만, 저처럼 개념 어쩌구저쩌구 늘려볼까",
-    date: "1995.12.14",
-    likeCount: 1000,
-  },
-  {
-    id: 2,
-    category: "React",
-    title: "useEffect는 언제 쓰나요?",
-    content:
-      "useEffect는 부수효과 처리용 훅으로, 컴포넌트가 마운트되거나 업데이트될 때 특정 로직을 실행하기 위해 사용됩니다...",
-    date: "2023.10.01",
-    likeCount: 284,
-  },
-];
+type UserAnswer = {
+  categoryName: string;
+  questionTitle: string;
+  answerContent: string;
+  createdAt: string;
+  likeCount: number;
+};
 
 export default function MyAnswerPage() {
+  const { user } = useAuthStore();
+  const [myAnswers, setMyAnswers] = useState<UserAnswer[]>([]);
+  const [isLoading, setIsLoading] = useState(true);
+
+  // Pagination
+  const [pageNumber, setPageNumber] = useState(1);
+  const [currentPageBlock, setCurrentPageBlock] = useState(1);
+  const totalCount = myAnswers.length;
+  const itemsPerPage = 5;
+  const paginatedAnswers = myAnswers.slice(
+    (pageNumber - 1) * itemsPerPage,
+    pageNumber * itemsPerPage
+  );
+
+  useEffect(() => {
+    const fetchAnswers = async () => {
+      if (!user?.email) return;
+      setIsLoading(true);
+      const res = await fetch(`/api/users/history?email=${user.email}`);
+      const data = await res.json();
+      setMyAnswers(data);
+      setIsLoading(false);
+    };
+    fetchAnswers();
+  }, [user?.email]);
+
+  if (isLoading) {
+    return (
+      <div className="flex flex-col gap-[var(--space-24)] mb-[100px]">
+        {Array.from({ length: 3 }).map((_, i) => (
+          <Card key={i} variant="default" className="space-y-9">
+            <div className="flex gap-4 items-center">
+              <Skeleton className="h-6 w-20" />
+              <Skeleton className="h-6 flex-1" />
+            </div>
+            <Skeleton className="h-5 w-full" />
+            <Skeleton className="h-5 w-[80%]" />
+          </Card>
+        ))}
+      </div>
+    );
+  }
+
   return (
     <div className="flex flex-col gap-[var(--space-24)] mb-[100px]">
-      {myAnswers.map((answer) => (
-        <Card key={answer.id} variant="default">
+      {paginatedAnswers.map((answer, index) => (
+        <Card key={index} variant="default">
           <div className="flex items-center gap-4 mb-4">
-            <Badge variant="default">{answer.category}</Badge>
-            <p className="txt-2xl-b line-clamp-1">{answer.title}</p>
+            <Badge variant="default">{answer.categoryName}</Badge>
+            <p className="txt-2xl-b line-clamp-1">{answer.questionTitle}</p>
           </div>
           <div className="flex flex-col gap-[var(--space-40)]">
-            <p className="line-clamp-2">{answer.content}</p>
+            <p className="line-clamp-2">{answer.answerContent}</p>
             <div className="flex justify-between items-center">
-              <p className="txt-sm !text-[var(--gray-02)]">{answer.date}</p>
+              <p className="txt-sm !text-[var(--gray-02)]">
+                {new Date(answer.createdAt).toLocaleDateString("ko-KR")}
+              </p>
               <div className="flex items-center gap-2 txt-sm !text-[var(--gray-02)]">
-                <Heart className="w-4 h-4 fill-red-500 stroke-none" />
+                <Heart className="w-4 h-4 fill-[var(--black)] stroke-none" />
                 <p>{formatNumber(answer.likeCount)}</p>
               </div>
             </div>
           </div>
         </Card>
       ))}
+
+      <Pagination
+        totalCount={totalCount}
+        itemsPerPage={5}
+        pageNumber={pageNumber}
+        currentPageBlock={currentPageBlock}
+        handleMovePage={setPageNumber}
+        handleMovePageBlock={setCurrentPageBlock}
+      />
     </div>
   );
 }

--- a/src/application/user/GetUserAnswerUsecase.ts
+++ b/src/application/user/GetUserAnswerUsecase.ts
@@ -1,0 +1,11 @@
+import { UserRepository } from "@/domain/repositories/UserRepository";
+import { UserAnswerDto } from "./dto/UserAnswerDto";
+
+export class GetUserAnswersUsecase {
+  constructor(private readonly userRepository: UserRepository) {}
+
+  async execute(email: string): Promise<UserAnswerDto[]> {
+    const answers = await this.userRepository.getUserAnswers(email);
+    return answers.map(UserAnswerDto.fromEntity);
+  }
+}

--- a/src/application/user/dto/UserAnswerDto.ts
+++ b/src/application/user/dto/UserAnswerDto.ts
@@ -1,0 +1,21 @@
+import { UserAnswer } from "@/domain/entities/UserAnswer";
+
+export class UserAnswerDto {
+  constructor(
+    public readonly categoryName: string,
+    public readonly questionTitle: string,
+    public readonly answerContent: string,
+    public readonly createdAt: string,
+    public readonly likeCount: number
+  ) {}
+
+  static fromEntity(entity: UserAnswer): UserAnswerDto {
+    return new UserAnswerDto(
+      entity.categoryName,
+      entity.questionTitle,
+      entity.answerContent,
+      entity.createdAt,
+      entity.likeCount
+    );
+  }
+}

--- a/src/application/user/dto/UserAnswerDto.ts
+++ b/src/application/user/dto/UserAnswerDto.ts
@@ -2,6 +2,7 @@ import { UserAnswer } from "@/domain/entities/UserAnswer";
 
 export class UserAnswerDto {
   constructor(
+    public readonly questionId: number,
     public readonly categoryName: string,
     public readonly questionTitle: string,
     public readonly answerContent: string,
@@ -11,6 +12,7 @@ export class UserAnswerDto {
 
   static fromEntity(entity: UserAnswer): UserAnswerDto {
     return new UserAnswerDto(
+      entity.questionId,
       entity.categoryName,
       entity.questionTitle,
       entity.answerContent,

--- a/src/components/common/Footer.tsx
+++ b/src/components/common/Footer.tsx
@@ -3,9 +3,9 @@ import Link from "next/link";
 
 export default function Footer() {
   return (
-    <footer className="flex flex-col md:flex-row justify-between items-center px-10 py-4 bg-[var(--blue-04)]">
-      <Link className="text-xl text-black" href="/">
-        <Image src="logo.svg" width={100} height={100} alt="logo" className="md:w-[200px]" />
+    <footer className="flex flex-col md:flex-row justify-between items-center h-[15vh] px-20 py-4 bg-[var(--blue-04)]">
+      <Link href="/">
+        <Image src="logo.svg" width={100} height={100} alt="logo" />
       </Link>
       <div className="flex flex-col md:flex-row items-center gap-4">
         <p className="text-sm text-gray-600">© 2025 lego. All rights reserved.</p>

--- a/src/components/ui/skeleton.tsx
+++ b/src/components/ui/skeleton.tsx
@@ -1,0 +1,13 @@
+import { cn } from "@/lib/utils"
+
+function Skeleton({ className, ...props }: React.ComponentProps<"div">) {
+  return (
+    <div
+      data-slot="skeleton"
+      className={cn("bg-accent animate-pulse rounded-md", className)}
+      {...props}
+    />
+  )
+}
+
+export { Skeleton }

--- a/src/domain/entities/UserAnswer.ts
+++ b/src/domain/entities/UserAnswer.ts
@@ -1,0 +1,9 @@
+export class UserAnswer {
+  constructor(
+    public readonly categoryName: string,
+    public readonly questionTitle: string,
+    public readonly answerContent: string,
+    public readonly createdAt: string,
+    public readonly likeCount: number
+  ) {}
+}

--- a/src/domain/entities/UserAnswer.ts
+++ b/src/domain/entities/UserAnswer.ts
@@ -1,5 +1,6 @@
 export class UserAnswer {
   constructor(
+    public readonly questionId: number,
     public readonly categoryName: string,
     public readonly questionTitle: string,
     public readonly answerContent: string,

--- a/src/domain/repositories/UserRepository.ts
+++ b/src/domain/repositories/UserRepository.ts
@@ -1,5 +1,7 @@
 import { UserActivity } from "../entities/UserActivity";
+import { UserAnswer } from "../entities/UserAnswer";
 
 export interface UserRepository {
   getUserActivity(email: string): Promise<UserActivity>;
+  getUserAnswers(email: string): Promise<UserAnswer[]>;
 }

--- a/src/infra/repositories/supabase/SbUserRepository.ts
+++ b/src/infra/repositories/supabase/SbUserRepository.ts
@@ -1,6 +1,7 @@
 import { UserRepository } from "@/domain/repositories/UserRepository";
 import { createClient } from "@/utils/supabase/server";
 import { UserActivity } from "@/domain/entities/UserActivity";
+import { UserAnswer } from "@/domain/entities/UserAnswer";
 
 export class SbUserRepository implements UserRepository {
   async getUserActivity(email: string): Promise<UserActivity> {
@@ -30,5 +31,55 @@ export class SbUserRepository implements UserRepository {
     const dailyActivity = Object.entries(dateMap).map(([date, count]) => ({ date, count }));
 
     return new UserActivity(email, count ?? 0, activeDays, dailyActivity);
+  }
+
+  async getUserAnswers(email: string): Promise<UserAnswer[]> {
+    const supabase = await createClient();
+
+    const { data, error } = await supabase
+      .from("answer")
+      .select(
+        `
+        question_id,
+        content,
+        created_at,
+        question:question (
+          content,
+          category:category (
+            name
+          )
+        )
+      `
+      )
+      .eq("email", email);
+
+    if (error || !data) {
+      console.error("Supabase 오류: ", error);
+      throw new Error("답변 조회 실패");
+    }
+
+    const result: UserAnswer[] = [];
+
+    for (const row of data) {
+      const { count } = await supabase
+        .from("like")
+        .select("*", { count: "exact", head: true })
+        .eq("question_id", row.question_id)
+        .eq("answer_email", email);
+
+      result.push(
+        new UserAnswer(
+          row.question.category.name,
+          row.question.content,
+          row.content,
+          row.created_at,
+          count ?? 0
+        )
+      );
+    }
+
+    console.log(result);
+
+    return result;
   }
 }

--- a/src/infra/repositories/supabase/SbUserRepository.ts
+++ b/src/infra/repositories/supabase/SbUserRepository.ts
@@ -69,6 +69,7 @@ export class SbUserRepository implements UserRepository {
 
       result.push(
         new UserAnswer(
+          row.question_id,
           row.question.category.name,
           row.question.content,
           row.content,
@@ -77,8 +78,6 @@ export class SbUserRepository implements UserRepository {
         )
       );
     }
-
-    console.log(result);
 
     return result;
   }

--- a/src/infra/repositories/supabase/SbUserRepository.ts
+++ b/src/infra/repositories/supabase/SbUserRepository.ts
@@ -51,7 +51,8 @@ export class SbUserRepository implements UserRepository {
         )
       `
       )
-      .eq("email", email);
+      .eq("email", email)
+      .order("created_at", { ascending: false });
 
     if (error || !data) {
       console.error("Supabase 오류: ", error);


### PR DESCRIPTION
## ✨ 작업 개요

마이페이지 - 내 답변(히스토리)에 필요한 데이터를 API로 받아와 UI에 추가했습니다.

## ✅ 상세 내용

- [x] 마이페이지 - 내 답변(히스토리) api 로직 추가
- [ ] 스켈레톤 UI, 페이지네이션 적용
- [ ] 메인 페이지에 카테고리 링크를 questions api에 맞게 적용
- [ ] Footer 로고 크기 조정

## 📸 스크린샷 (선택)

### 기본 구성, 페이지네이션
<img width="400" alt="image" src="https://github.com/user-attachments/assets/ab70131c-1d22-4e91-b908-a9b17bfb064a" />
<img width="400" alt="image" src="https://github.com/user-attachments/assets/1e277062-0dd3-49fa-bf5e-dd948ac283fe" />

### 로딩 상태에 따른 스켈레톤 UI 적용
<img width="1113" alt="image" src="https://github.com/user-attachments/assets/a51c6aae-7e5e-4d12-aae8-0d25fa997feb" />



## 🧪 확인 사항

- [ ] 정상적으로 동작하는지 직접 테스트해봤나요?
- [ ] 기능 추가/수정 후 UI나 비즈니스 로직에 영향은 없나요?
- [ ] PR 리뷰어가 중점적으로 확인하면 좋을 부분은?

## 🙏 기타 참고 사항
- 데이터 정렬 기준은 최신순입니다.