### PR TITLE
마이 페이지 - 좋아요 한 답변(히스토리) API 연동

### DIFF
--- a/src/app/api/users/history/likes/route.ts
+++ b/src/app/api/users/history/likes/route.ts
@@ -1,0 +1,23 @@
+import { NextRequest, NextResponse } from "next/server";
+import { GetUserLikedAnswersUsecase } from "@/application/user/GetUserLikedAnswerUsecase";
+import { SbUserRepository } from "@/infra/repositories/supabase/SbUserRepository";
+import { UserLikedAnswerDto } from "@/application/user/dto/UserLikedAnswerDto";
+
+const usecase = new GetUserLikedAnswersUsecase(new SbUserRepository());
+
+export async function GET(request: NextRequest) {
+  const email = request.nextUrl.searchParams.get("email");
+  if (!email) return NextResponse.json({ error: "이메일이 필요합니다." }, { status: 400 });
+
+  try {
+    const likedAnswers = await usecase.execute(email);
+    const result = likedAnswers.map(UserLikedAnswerDto.fromEntity); // 🔥 변환 적용
+    return NextResponse.json(result, { status: 200 });
+  } catch (error) {
+    console.error("좋아요한 답변 조회 실패:", error);
+    return NextResponse.json(
+      { error: "좋아요한 답변 정보를 불러오지 못했습니다." },
+      { status: 500 }
+    );
+  }
+}

--- a/src/app/users/components/Bookmark.tsx
+++ b/src/app/users/components/Bookmark.tsx
@@ -59,7 +59,13 @@ export default function BookmarkPage() {
         <Link href={`/questions/${item.questionId}?userId=${user?.email}`} key={item.questionId}>
           <Card variant="tight" className="flex items-center justify-between">
             <div className="txt-2xl-b flex items-center gap-6 cursor-pointer w-[90%]">
-              <Image src={item.categoryImageUrl} width={32} height={32} alt="카테고리 아이콘" />
+              <Image
+                src={item.categoryImageUrl}
+                width={32}
+                height={32}
+                alt="카테고리 아이콘"
+                className="rounded-md"
+              />
               <p className="line-clamp-1 w-4/5">{item.questionTitle}</p>
             </div>
             <Bookmark className="fill-[var(--black)] stroke-none" />

--- a/src/app/users/components/LikeAnswer.tsx
+++ b/src/app/users/components/LikeAnswer.tsx
@@ -1,54 +1,95 @@
 "use client";
 
+import { useEffect, useState } from "react";
 import { Avatar, AvatarFallback, AvatarImage } from "@/components/ui/avatar";
 import { Card } from "@/components/ui/card";
 import { useAuthStore } from "@/store/useAuthStore";
+import { Skeleton } from "@/components/ui/skeleton";
+import { Pagination } from "@/components/ui/pagination";
+import Link from "next/link";
+
+type LikedAnswer = {
+  questionId: number;
+  answerContent: string;
+  answerAuthor: string;
+  answerAuthorEmail: string;
+  createdAt: string;
+  avatarUrl: string;
+};
 
 export default function LikeAnswerPage() {
   const { user } = useAuthStore();
+  const [likedAnswers, setLikedAnswers] = useState<LikedAnswer[]>([]);
+  const [isLoading, setIsLoading] = useState(true);
 
-  const likedAnswers = [
-    {
-      id: 1,
-      content:
-        "Next.js는 버전 13부터 React 18에서 도입된 서버 컴포넌트를 지원하고 있습니다. Next.js는 버전 13부터 React 18에서 도입된 서버 컴포넌트를 지원하고 있습니다. Next.js는 버전 13부터 React 18에서 도입된 서버 컴포넌트를 지원하고 있습니다.",
-      user: {
-        name: "아무개",
-        avatarUrl: user?.avatarUrl,
-      },
-      createdAt: "2025.01.01",
-    },
-    {
-      id: 2,
-      content:
-        "React의 useEffect는 컴포넌트가 마운트되거나 업데이트될 때 실행되는 훅입니다. React의 useEffect는 컴포넌트가 마운트되거나 업데이트될 때 실행되는 훅입니다. React의 useEffect는 컴포넌트가 마운트되거나 업데이트될 때 실행되는 훅입니다.",
-      user: {
-        name: "홍길동",
-        avatarUrl: user?.avatarUrl,
-      },
-      createdAt: "2025.01.02",
-    },
-  ];
+  const [pageNumber, setPageNumber] = useState(1);
+  const [currentPageBlock, setCurrentPageBlock] = useState(1);
+  const totalCount = likedAnswers.length;
+  const itemsPerPage = 5;
+  const paginatedData = likedAnswers.slice(
+    (pageNumber - 1) * itemsPerPage,
+    pageNumber * itemsPerPage
+  );
+  useEffect(() => {
+    if (!user?.email) return;
+
+    const fetchLikedAnswers = async () => {
+      setIsLoading(true);
+      const res = await fetch(`/api/users/history/likes?email=${user.email}`);
+      const data = await res.json();
+      setLikedAnswers(data);
+      setIsLoading(false);
+    };
+
+    fetchLikedAnswers();
+  }, [user?.email]);
+
+  if (isLoading) {
+    return (
+      <div className="flex flex-col gap-6 mb-[100px]">
+        {Array.from({ length: 2 }).map((_, i) => (
+          <Card key={i} variant="default" className="space-y-4">
+            <div className="flex gap-4">
+              <Skeleton className="w-10 h-10 rounded-full" />
+              <Skeleton className="h-6 flex-1" />
+            </div>
+            <Skeleton className="h-4 w-1/2" />
+          </Card>
+        ))}
+      </div>
+    );
+  }
 
   return (
     <div className="flex flex-col gap-6 mb-[100px]">
-      {likedAnswers.map((item) => (
-        <Card key={item.id} variant="default">
-          <div className="flex flex-col gap-4">
-            <div className="flex gap-4">
-              <Avatar>
-                <AvatarImage src={item.user.avatarUrl} alt="프로필 이미지" />
-                <AvatarFallback>{item.user.name[0] ?? "?"}</AvatarFallback>
-              </Avatar>
-              <p className="line-clamp-2">{item.content}</p>
+      {paginatedData.map((item, index) => (
+        <Link key={index} href={`/questions/${item.questionId}/answers/${item.answerAuthorEmail}`}>
+          <Card variant="default">
+            <div className="flex flex-col gap-4">
+              <div className="flex gap-4">
+                <Avatar>
+                  <AvatarImage src={item.avatarUrl} alt="프로필 이미지" />
+                  <AvatarFallback>{item.answerAuthor[0] ?? "?"}</AvatarFallback>
+                </Avatar>
+                <p className="line-clamp-2">{item.answerContent}</p>
+              </div>
+              <div className="flex items-center gap-2 txt-sm !text-[var(--gray-02)]">
+                <p>{item.answerAuthor}</p>
+                <p>{new Date(item.createdAt).toLocaleDateString("ko-KR")}</p>
+              </div>
             </div>
-            <div className="flex items-center gap-2 txt-sm !text-[var(--gray-02)]">
-              <p>{item.user.name}</p>
-              <p>{item.createdAt}</p>
-            </div>
-          </div>
-        </Card>
+          </Card>
+        </Link>
       ))}
+
+      <Pagination
+        totalCount={totalCount}
+        itemsPerPage={itemsPerPage}
+        pageNumber={pageNumber}
+        currentPageBlock={currentPageBlock}
+        handleMovePage={setPageNumber}
+        handleMovePageBlock={setCurrentPageBlock}
+      />
     </div>
   );
 }

--- a/src/app/users/components/LikeAnswer.tsx
+++ b/src/app/users/components/LikeAnswer.tsx
@@ -63,7 +63,10 @@ export default function LikeAnswerPage() {
   return (
     <div className="flex flex-col gap-6 mb-[100px]">
       {paginatedData.map((item, index) => (
-        <Link key={index} href={`/questions/${item.questionId}/answers/${item.answerAuthorEmail}`}>
+        <Link
+          key={index}
+          href={`/questions/${item.questionId}/answers?userId=${item.answerAuthorEmail}`}
+        >
           <Card variant="default">
             <div className="flex flex-col gap-4">
               <div className="flex gap-4">

--- a/src/app/users/components/MyAnswer.tsx
+++ b/src/app/users/components/MyAnswer.tsx
@@ -91,7 +91,7 @@ export default function MyAnswerPage() {
 
       <Pagination
         totalCount={totalCount}
-        itemsPerPage={5}
+        itemsPerPage={itemsPerPage}
         pageNumber={pageNumber}
         currentPageBlock={currentPageBlock}
         handleMovePage={setPageNumber}

--- a/src/application/user/GetUserLikedAnswerUsecase.ts
+++ b/src/application/user/GetUserLikedAnswerUsecase.ts
@@ -1,0 +1,10 @@
+import { UserRepository } from "@/domain/repositories/UserRepository";
+import { UserLikedAnswerDto } from "@/application/user/dto/UserLikedAnswerDto";
+
+export class GetUserLikedAnswersUsecase {
+  constructor(private readonly repository: UserRepository) {}
+
+  async execute(email: string): Promise<UserLikedAnswerDto[]> {
+    return this.repository.getUserLikedAnswers(email);
+  }
+}

--- a/src/application/user/dto/UserLikedAnswerDto.ts
+++ b/src/application/user/dto/UserLikedAnswerDto.ts
@@ -5,6 +5,8 @@ export class UserLikedAnswerDto {
     public readonly questionId: number,
     public readonly answerContent: string,
     public readonly answerAuthor: string,
+    public readonly answerAuthorEmail: string,
+    public readonly avatarUrl: string,
     public readonly createdAt: string
   ) {}
 
@@ -13,6 +15,8 @@ export class UserLikedAnswerDto {
       entity.questionId,
       entity.answerContent,
       entity.answerAuthor,
+      entity.answerAuthorEmail,
+      entity.avatarUrl,
       entity.createdAt
     );
   }

--- a/src/application/user/dto/UserLikedAnswerDto.ts
+++ b/src/application/user/dto/UserLikedAnswerDto.ts
@@ -1,0 +1,19 @@
+import { UserLikedAnswer } from "@/domain/entities/UserLike";
+
+export class UserLikedAnswerDto {
+  constructor(
+    public readonly questionId: number,
+    public readonly answerContent: string,
+    public readonly answerAuthor: string,
+    public readonly createdAt: string
+  ) {}
+
+  static fromEntity(entity: UserLikedAnswer): UserLikedAnswerDto {
+    return new UserLikedAnswerDto(
+      entity.questionId,
+      entity.answerContent,
+      entity.answerAuthor,
+      entity.createdAt
+    );
+  }
+}

--- a/src/domain/entities/UserLike.ts
+++ b/src/domain/entities/UserLike.ts
@@ -1,0 +1,8 @@
+export class UserLikedAnswer {
+  constructor(
+    public readonly questionId: number,
+    public readonly answerContent: string,
+    public readonly answerAuthor: string,
+    public readonly createdAt: string
+  ) {}
+}

--- a/src/domain/entities/UserLike.ts
+++ b/src/domain/entities/UserLike.ts
@@ -3,6 +3,8 @@ export class UserLikedAnswer {
     public readonly questionId: number,
     public readonly answerContent: string,
     public readonly answerAuthor: string,
+    public readonly answerAuthorEmail: string,
+    public readonly avatarUrl: string,
     public readonly createdAt: string
   ) {}
 }

--- a/src/domain/repositories/UserRepository.ts
+++ b/src/domain/repositories/UserRepository.ts
@@ -1,9 +1,11 @@
 import { UserActivity } from "@/domain/entities/UserActivity";
 import { UserAnswer } from "@/domain/entities/UserAnswer";
 import { UserBookmark } from "@/domain/entities/UserBookmark";
+import { UserLikedAnswer } from "@/domain/entities/UserLike";
 
 export interface UserRepository {
   getUserActivity(email: string): Promise<UserActivity>;
   getUserAnswers(email: string): Promise<UserAnswer[]>;
   getUserBookmarks(email: string): Promise<UserBookmark[]>;
+  getUserLikedAnswers(email: string): Promise<UserLikedAnswer[]>;
 }

--- a/src/infra/repositories/supabase/SbUserRepository.ts
+++ b/src/infra/repositories/supabase/SbUserRepository.ts
@@ -127,8 +127,10 @@ export class SbUserRepository implements UserRepository {
           answer:answer (
             question_id,
             content,
-            created_at,
-            username
+            username,
+            email,
+            avatar_url,
+            created_at
           )
         `
       )
@@ -144,6 +146,8 @@ export class SbUserRepository implements UserRepository {
         row.answer.question_id,
         row.answer.content,
         row.answer.username,
+        row.answer.email,
+        row.answer.avatar_url,
         row.answer.created_at
       );
     });

--- a/src/infra/repositories/supabase/SbUserRepository.ts
+++ b/src/infra/repositories/supabase/SbUserRepository.ts
@@ -3,6 +3,7 @@ import { createClient } from "@/utils/supabase/server";
 import { UserActivity } from "@/domain/entities/UserActivity";
 import { UserAnswer } from "@/domain/entities/UserAnswer";
 import { UserBookmark } from "@/domain/entities/UserBookmark";
+import { UserLikedAnswer } from "@/domain/entities/UserLike";
 
 export class SbUserRepository implements UserRepository {
   async getUserActivity(email: string): Promise<UserActivity> {
@@ -112,6 +113,38 @@ export class SbUserRepository implements UserRepository {
         row.question.id,
         row.question.content,
         row.question.category.image_url
+      );
+    });
+  }
+
+  async getUserLikedAnswers(email: string): Promise<UserLikedAnswer[]> {
+    const supabase = await createClient();
+
+    const { data, error } = await supabase
+      .from("like")
+      .select(
+        `
+          answer:answer (
+            question_id,
+            content,
+            created_at,
+            username
+          )
+        `
+      )
+      .eq("like_email", email);
+
+    if (error || !data) {
+      console.error("좋아요한 답변 조회 오류:", error);
+      throw new Error("좋아요한 답변을 조회하지 못했습니다.");
+    }
+
+    return data.map((row) => {
+      return new UserLikedAnswer(
+        row.answer.question_id,
+        row.answer.content,
+        row.answer.username,
+        row.answer.created_at
       );
     });
   }


### PR DESCRIPTION
## ✨ 작업 개요

- 마이페이지 - 좋아요 한 답변(히스토리)에 필요한 데이터를 API로 받아와 UI에 추가했습니다.

## ✅ 상세 내용

- [x] 마이페이지 - 좋아요 한 답변(히스토리) api 로직 추가
- [x] 스켈레톤 UI, 페이지네이션 적용

## 📸 스크린샷 (선택)

## 🧪 확인 사항

- [x] 정상적으로 동작하는지 직접 테스트해봤나요?
- [x] 기능 추가/수정 후 UI나 비즈니스 로직에 영향은 없나요?
- [x] PR 리뷰어가 중점적으로 확인하면 좋을 부분은?

## 🙏 기타 참고 사항