### PR TITLE
마이 페이지 - 댓글(히스토리) API 연동

### DIFF
--- a/src/app/api/users/history/comments/route.ts
+++ b/src/app/api/users/history/comments/route.ts
@@ -1,0 +1,18 @@
+import { NextRequest, NextResponse } from "next/server";
+import { GetUserCommentsUsecase } from "@/application/user/GetUserCommentsUsecase";
+import { SbUserRepository } from "@/infra/repositories/supabase/SbUserRepository";
+
+const usecase = new GetUserCommentsUsecase(new SbUserRepository());
+
+export async function GET(request: NextRequest) {
+  const email = request.nextUrl.searchParams.get("email");
+  if (!email) return NextResponse.json({ error: "이메일이 필요합니다." }, { status: 400 });
+
+  try {
+    const comments = await usecase.execute(email);
+    return NextResponse.json(comments, { status: 200 });
+  } catch (error) {
+    console.error("댓글 조회 실패:", error);
+    return NextResponse.json({ error: "댓글 정보를 불러오지 못했습니다." }, { status: 500 });
+  }
+}

--- a/src/application/user/GetUserCommentsUsecase.ts
+++ b/src/application/user/GetUserCommentsUsecase.ts
@@ -1,0 +1,10 @@
+import { UserRepository } from "@/domain/repositories/UserRepository";
+import { UserCommentDto } from "@/application/user/dto/UserCommentDto";
+
+export class GetUserCommentsUsecase {
+  constructor(private readonly repository: UserRepository) {}
+
+  async execute(email: string): Promise<UserCommentDto[]> {
+    return this.repository.getUserComments(email);
+  }
+}

--- a/src/application/user/dto/UserCommentDto.ts
+++ b/src/application/user/dto/UserCommentDto.ts
@@ -1,0 +1,19 @@
+import { UserComment } from "@/domain/entities/UserComment";
+
+export class UserCommentDto {
+  constructor(
+    public readonly questionId: number,
+    public readonly questionTitle: string,
+    public readonly commentContent: string,
+    public readonly answerAuthorEmail: string
+  ) {}
+
+  static fromEntity(entity: UserComment): UserCommentDto {
+    return new UserCommentDto(
+      entity.questionId,
+      entity.questionTitle,
+      entity.commentContent,
+      entity.answerAuthorEmail
+    );
+  }
+}

--- a/src/domain/entities/UserComment.ts
+++ b/src/domain/entities/UserComment.ts
@@ -1,0 +1,8 @@
+export class UserComment {
+  constructor(
+    public readonly questionId: number,
+    public readonly questionTitle: string,
+    public readonly commentContent: string,
+    public readonly answerAuthorEmail: string
+  ) {}
+}

--- a/src/domain/repositories/UserRepository.ts
+++ b/src/domain/repositories/UserRepository.ts
@@ -2,10 +2,12 @@ import { UserActivity } from "@/domain/entities/UserActivity";
 import { UserAnswer } from "@/domain/entities/UserAnswer";
 import { UserBookmark } from "@/domain/entities/UserBookmark";
 import { UserLikedAnswer } from "@/domain/entities/UserLike";
+import { UserComment } from "@/domain/entities/UserComment";
 
 export interface UserRepository {
   getUserActivity(email: string): Promise<UserActivity>;
   getUserAnswers(email: string): Promise<UserAnswer[]>;
   getUserBookmarks(email: string): Promise<UserBookmark[]>;
   getUserLikedAnswers(email: string): Promise<UserLikedAnswer[]>;
+  getUserComments(email: string): Promise<UserComment[]>;
 }


### PR DESCRIPTION
## ✨ 작업 개요

- 마이페이지 - 댓글(히스토리)에 필요한 데이터를 API로 받아와 UI에 추가했습니다.

## ✅ 상세 내용

- [x] 마이페이지 - 댓글(히스토리) api 로직 추가
- [x] 스켈레톤 UI, 페이지네이션 적용

## 📸 스크린샷 (선택)

## 🧪 확인 사항

- [x] 정상적으로 동작하는지 직접 테스트해봤나요?
- [x] 기능 추가/수정 후 UI나 비즈니스 로직에 영향은 없나요?
- [x] PR 리뷰어가 중점적으로 확인하면 좋을 부분은?

## 🙏 기타 참고 사항