### PR TITLE
댓글 수정, 삭제 API 버그 픽스 및 수정

### DIFF
--- a/src/app/api/comments/[id]/route.ts
+++ b/src/app/api/comments/[id]/route.ts
@@ -4,9 +4,13 @@ import { UpdateCommentUsecase } from "@/application/usecase/comment/UpdateCommen
 import { UpdateCommentDto } from "@/application/usecase/comment/dto/UpdateCommentDto";
 import { DeleteCommentUsecase } from "@/application/usecase/comment/DeleteCommentUsecase";
 
-//댓글 수정
-export async function PATCH(req: NextRequest, { params }: { params: { id: string } }) {
-  const id = Number(params.id);
+// 댓글 수정
+export async function PATCH(req: NextRequest) {
+  // ✅ request URL에서 직접 ID 파싱
+  const url = req.nextUrl.pathname; // /api/comments/123
+  const idStr = url.split("/").pop(); // '123'
+  const id = Number(idStr);
+
   const { content } = await req.json();
 
   if (!id || !content) {
@@ -20,16 +24,18 @@ export async function PATCH(req: NextRequest, { params }: { params: { id: string
   return NextResponse.json({ message: "댓글이 수정되었습니다." });
 }
 
-//댓글 삭제
-export async function DELETE(_: NextRequest, { params }: { params: { id: string } }) {
-    const id = Number(params.id);
-  
-    if (!id) {
-      return NextResponse.json({ error: "Invalid comment ID" }, { status: 400 });
-    }
-  
-    const usecase = new DeleteCommentUsecase(new SbCommentRepository());
-    await usecase.execute(id);
-  
-    return NextResponse.json({ message: "댓글이 삭제되었습니다." });
+// 댓글 삭제(댓글 수정 방식이랑 동일하게 작동)
+export async function DELETE(req: NextRequest) {
+  const url = req.nextUrl.pathname;
+  const idStr = url.split("/").pop();
+  const id = Number(idStr);
+
+  if (!id) {
+    return NextResponse.json({ error: "Invalid comment ID" }, { status: 400 });
+  }
+
+  const usecase = new DeleteCommentUsecase(new SbCommentRepository());
+  await usecase.execute(id);
+
+  return NextResponse.json({ message: "댓글이 삭제되었습니다." });
 }


### PR DESCRIPTION
## ✨ 작업 개요

ex. 댓글 수정, 삭제 API 버그 픽스 및 수정

## ✅ 상세 내용

- [ ] 댓글 수정, 삭제 API에서 사용하는 params.id 를 사용하는 부분을 빼고 req.nextUrl.pathname을 통해 직접 parsing 해서 id에 접근

## 📸 스크린샷 (선택)

## 🧪 확인 사항

- [ ] 정상적으로 동작하는지 직접 테스트해봤나요?
- [ ] 기능 추가/수정 후 UI나 비즈니스 로직에 영향은 없나요?
- [ ] PR 리뷰어가 중점적으로 확인하면 좋을 부분은?

## 🙏 기타 참고 사항
