### PR TITLE
문제 리스트 반응형 디자인 추가

### DIFF
--- a/src/app/questions/page.tsx
+++ b/src/app/questions/page.tsx
@@ -240,15 +240,15 @@ export default function QuestionListPage() {
   return (
     <div className="w-full container mx-auto pt-[40px]">
       <div className="relative w-full max-w-[948px] h-[115px] mb-6 overflow-hidden md:h-[115px] sm:h-[80px]">
-  <Image
-    src="/assets/images/banner.svg"
-    alt="배너 이미지"
-    fill
-    priority
-    sizes="(max-width: 768px) 100vw, 948px"
-    className="object-cover rounded-md"
-  />
-</div>
+        <Image
+          src="/assets/images/banner.svg"
+          alt="배너 이미지"
+          fill
+          priority
+          sizes="(max-width: 768px) 100vw, 948px"
+          className="object-cover rounded-md"
+        />
+      </div>
 
       <div className="flex items-center gap-2">
         <Input
@@ -272,24 +272,24 @@ export default function QuestionListPage() {
 
       <div className="mb-[12px]" />
 
-      <div className="flex items-center gap-2 mb-6">
+      <div className="flex flex-row items-center gap-2 mb-6 justify-center sm:justify-start">
         <Select onValueChange={throttledHandleCategoryChange} value={selectedCategoryName}>
-          <SelectTrigger className="w-[204px] h-[40px] text-[var(--black)]">
+          <SelectTrigger className="w-[45vw] h-[40px] text-[var(--black)] sm:w-[204px]">
             <SelectValue placeholder="전체" />
           </SelectTrigger>
           <SelectContent>
             <SelectItem value="전체">전체</SelectItem>
-            {categories.map((category) => (
-              <SelectItem key={category.id} value={category.name}>
-                {category.name}
-              </SelectItem>
-            ))}
+              {categories.map((category) => (
+                <SelectItem key={category.id} value={category.name}>
+                  {category.name}
+                </SelectItem>
+              ))}
           </SelectContent>
         </Select>
 
         {isLoggedIn && (
-          <Select onValueChange={throttledHandleFilterChange} value={filterOption}>
-            <SelectTrigger className="w-[204px] h-[40px] text-[var(--black)]">
+        <Select onValueChange={throttledHandleFilterChange} value={filterOption}>
+            <SelectTrigger className="w-[45vw] h-[40px] text-[var(--black)] sm:w-[204px]">
               <SelectValue placeholder="필터" />
             </SelectTrigger>
             <SelectContent>
@@ -297,9 +297,10 @@ export default function QuestionListPage() {
               <SelectItem value="bookmarked">북마크한 문제</SelectItem>
               <SelectItem value="answered">답변한 문제</SelectItem>
             </SelectContent>
-          </Select>
+        </Select>
         )}
       </div>
+
 
       <div className="flex items-center justify-between mb-[12px]">
         <h2 className="txt-lg-b">문제</h2>

--- a/src/app/questions/page.tsx
+++ b/src/app/questions/page.tsx
@@ -239,16 +239,16 @@ export default function QuestionListPage() {
   const pagedQuestions = visibleQuestions.slice(startIdx, endIdx);
   return (
     <div className="w-full container mx-auto pt-[40px]">
-      <div className="relative w-[948px] h-[115px] mb-6 overflow-hidden">
-        <Image
-          src="/assets/images/banner.svg"
-          alt="배너 이미지"
-          fill
-          priority
-          sizes="948px"
-          className="object-cover rounded-md"
-        />
-      </div>
+      <div className="relative w-full max-w-[948px] h-[115px] mb-6 overflow-hidden md:h-[115px] sm:h-[80px]">
+  <Image
+    src="/assets/images/banner.svg"
+    alt="배너 이미지"
+    fill
+    priority
+    sizes="(max-width: 768px) 100vw, 948px"
+    className="object-cover rounded-md"
+  />
+</div>
 
       <div className="flex items-center gap-2">
         <Input
@@ -342,17 +342,22 @@ export default function QuestionListPage() {
                   >
                     <Card className="cursor-pointer">
                       <div className="flex h-full items-center justify-between">
-                        <div className="flex items-center gap-4">
+                      {/* 왼쪽 (이미지 + 문제 제목) */}
+                        <div className="flex items-center gap-4 min-w-0 flex-1">
                           <Image
                             src={getImageUrlByCategory(question.categoryId)}
                             alt="문제 카테고리"
                             width={32}
                             height={32}
-                            className="rounded-md"
+                            className="rounded-md flex-shrink-0"
                           />
-                          <span className="txt-xl-b line-clamp-1">{question.content}</span>
+                          <span className="txt-xl-b line-clamp-1">
+                            {question.content}
+                          </span>
                         </div>
-                        <div className="flex items-center gap-4 text-[14px] font-bold leading-[150%] text-[var(--gray-02)]">
+
+                      {/* 오른쪽 (북마크/답변 수) */}
+                        <div className="flex flex-shrink-0 flex-col items-end gap-1 font-bold leading-[150%] text-[14px] text-[var(--gray-02)] sm:flex-row sm:items-center sm:gap-4">
                           <span>북마크 {question.bookmark_count}</span>
                           <span>답변 {question.answer_count}</span>
                         </div>

--- a/src/app/questions/page.tsx
+++ b/src/app/questions/page.tsx
@@ -312,7 +312,7 @@ export default function QuestionListPage() {
           variant="ghost"
           size="sm"
           onClick={() => handleSortClick("bookmark")}
-          className={selectedSort === "bookmark" ? "!text-[var(--black)]" : ""}
+          className={selectedSort === "bookmark" ? "!text-[var(--blue-02)]" : ""}
         >
           인기순
         </Button>
@@ -320,7 +320,7 @@ export default function QuestionListPage() {
           variant="ghost"
           size="sm"
           onClick={() => handleSortClick("recent")}
-          className={selectedSort === "recent" ? "!text-[var(--black)]" : ""}
+          className={selectedSort === "recent" ? "!text-[var(--blue-02)]" : ""}
         >
           최신순
         </Button>

--- a/src/app/questions/page.tsx
+++ b/src/app/questions/page.tsx
@@ -272,37 +272,36 @@ export default function QuestionListPage() {
 
       <div className="mb-[12px]" />
 
-      <div className={`flex flex-row items-center gap-2 mb-6 ${
-        isLoggedIn ? "justify-center" : "justify-start"
-        } 
-        sm:justify-start`}>
-        <Select onValueChange={throttledHandleCategoryChange} value={selectedCategoryName}>
-          <SelectTrigger className="w-[50vw] h-[40px] text-[var(--black)] sm:w-[204px]">
-            <SelectValue placeholder="전체" />
-          </SelectTrigger>
-          <SelectContent>
-            <SelectItem value="전체">전체</SelectItem>
-              {categories.map((category) => (
-                <SelectItem key={category.id} value={category.name}>
-                  {category.name}
-                </SelectItem>
-              ))}
-          </SelectContent>
-        </Select>
+      <div className={`flex flex-row flex-wrap items-center gap-2 mb-6 
+  justify-start`}>
+  
+  <Select onValueChange={throttledHandleCategoryChange} value={selectedCategoryName}>
+    <SelectTrigger className="w-[160px] sm:w-[204px] h-[40px] text-[var(--black)]">
+      <SelectValue placeholder="전체" />
+    </SelectTrigger>
+    <SelectContent>
+      <SelectItem value="전체">전체</SelectItem>
+      {categories.map((category) => (
+        <SelectItem key={category.id} value={category.name}>
+          {category.name}
+        </SelectItem>
+      ))}
+    </SelectContent>
+  </Select>
 
-        {isLoggedIn && (
-        <Select onValueChange={throttledHandleFilterChange} value={filterOption}>
-            <SelectTrigger className="w-[50vw] h-[40px] text-[var(--black)] sm:w-[204px]">
-              <SelectValue placeholder="필터" />
-            </SelectTrigger>
-            <SelectContent>
-              <SelectItem value="all">전체</SelectItem>
-              <SelectItem value="bookmarked">북마크한 문제</SelectItem>
-              <SelectItem value="answered">답변한 문제</SelectItem>
-            </SelectContent>
-        </Select>
-        )}
-      </div>
+  {isLoggedIn && (
+    <Select onValueChange={throttledHandleFilterChange} value={filterOption}>
+      <SelectTrigger className="w-[160px] sm:w-[204px] h-[40px] text-[var(--black)]">
+        <SelectValue placeholder="필터" />
+      </SelectTrigger>
+      <SelectContent>
+        <SelectItem value="all">전체</SelectItem>
+        <SelectItem value="bookmarked">북마크한 문제</SelectItem>
+        <SelectItem value="answered">답변한 문제</SelectItem>
+      </SelectContent>
+    </Select>
+  )}
+</div>
 
 
       <div className="flex items-center justify-between mb-[12px]">

--- a/src/app/questions/page.tsx
+++ b/src/app/questions/page.tsx
@@ -272,7 +272,10 @@ export default function QuestionListPage() {
 
       <div className="mb-[12px]" />
 
-      <div className="flex flex-row items-center gap-2 mb-6 justify-center sm:justify-start">
+      <div className={`flex flex-row items-center gap-2 mb-6 ${
+        isLoggedIn ? "justify-center" : "justify-start"
+        } 
+        sm:justify-start`}>
         <Select onValueChange={throttledHandleCategoryChange} value={selectedCategoryName}>
           <SelectTrigger className="w-[45vw] h-[40px] text-[var(--black)] sm:w-[204px]">
             <SelectValue placeholder="전체" />

--- a/src/app/questions/page.tsx
+++ b/src/app/questions/page.tsx
@@ -277,7 +277,7 @@ export default function QuestionListPage() {
         } 
         sm:justify-start`}>
         <Select onValueChange={throttledHandleCategoryChange} value={selectedCategoryName}>
-          <SelectTrigger className="w-[45vw] h-[40px] text-[var(--black)] sm:w-[204px]">
+          <SelectTrigger className="w-[50vw] h-[40px] text-[var(--black)] sm:w-[204px]">
             <SelectValue placeholder="전체" />
           </SelectTrigger>
           <SelectContent>
@@ -292,7 +292,7 @@ export default function QuestionListPage() {
 
         {isLoggedIn && (
         <Select onValueChange={throttledHandleFilterChange} value={filterOption}>
-            <SelectTrigger className="w-[45vw] h-[40px] text-[var(--black)] sm:w-[204px]">
+            <SelectTrigger className="w-[50vw] h-[40px] text-[var(--black)] sm:w-[204px]">
               <SelectValue placeholder="필터" />
             </SelectTrigger>
             <SelectContent>

--- a/src/app/questions/page.tsx
+++ b/src/app/questions/page.tsx
@@ -49,6 +49,8 @@ export default function QuestionListPage() {
   const user = useAuthStore((state) => state.user);
   const userEmail = user?.email;
 
+  const [selectedSort, setSelectedSort] = useState<"bookmark" | "recent">("recent");
+
   const filterOption = (filter as "all" | "bookmarked" | "answered") ?? "all";
 
   // ✅ 추가
@@ -206,6 +208,7 @@ export default function QuestionListPage() {
   }, 500);
 
   const handleSortClick = (sortBy: "recent" | "bookmark") => {
+    setSelectedSort(sortBy);
     const params = new URLSearchParams(paramsString);
     params.set("sortBy", sortBy);
     router.push(`/questions?${params.toString()}`);
@@ -301,13 +304,23 @@ export default function QuestionListPage() {
       <div className="flex items-center justify-between mb-[12px]">
         <h2 className="txt-lg-b">문제</h2>
         <div className="flex">
-          <Button variant="ghost" size="sm" onClick={() => handleSortClick("bookmark")}>
-            인기순
-          </Button>
-          <Button variant="ghost" size="sm" onClick={() => handleSortClick("recent")}>
-            최신순
-          </Button>
-        </div>
+        <Button
+          variant="ghost"
+          size="sm"
+          onClick={() => handleSortClick("bookmark")}
+          className={selectedSort === "bookmark" ? "!text-[var(--black)]" : ""}
+        >
+          인기순
+        </Button>
+        <Button
+          variant="ghost"
+          size="sm"
+          onClick={() => handleSortClick("recent")}
+          className={selectedSort === "recent" ? "!text-[var(--black)]" : ""}
+        >
+          최신순
+        </Button>
+      </div>
       </div>
 
       <div className="flex justify-center min-h-[300px]">


### PR DESCRIPTION
## ✨ 작업 개요

* 문제 리스트 반응형 디자인 추가 및 인기순/최신순 버튼 적용효과 추가

## ✅ 상세 내용

- [ ] 인기순/최신순 버튼 적용 효과 추가(선택시 검은 글씨로 활성화 알림)
- [ ] 배너 이미지에 대한 모바일 반응형 디자인 설정
- [ ] ~두 셀렉트 박스에 대한 모바일 반응형 디자인 설정(모바일: 가로 이웃한 채 너비를 화면 크기에 맞춰서 출력)~
- [ ] 북마크 수, 답변 수 에 대한 모바일 반응형 디자인(데스크탑: 가로로 이웃, 모바일: 세로로 정렬)

## 📸 스크린샷 (선택)

* 로그인 사용자 모바일 최신순 문제리스트 화면

![모바일 로그인 최신순 출력 화면](https://github.com/user-attachments/assets/82a1d999-e833-4761-a0ca-2d6a0bf80e88)


* 로그인 사용자 모바일 인기순 문제리스트 화면

![모바일 로그인 인기순 출력 화면](https://github.com/user-attachments/assets/64068cb7-5f3b-4df7-a19a-431c2cd44386)


* 로그아웃 사용자 모바일 최신순 문제리스트 화면

![모바일 로그아웃 최신순 출력 화면](https://github.com/user-attachments/assets/88566976-d53c-4805-ac19-22c38ecd0ec4)


* 로그아웃 사용자 모바일 인기순 문제리스트 화면

![모바일 로그아웃 인기순 출력 화면](https://github.com/user-attachments/assets/caf64746-8bbf-4122-b117-d3d9f3c13e96)


## 🧪 확인 사항

- [ ] 정상적으로 동작하는지 직접 테스트해봤나요?
- [ ] 기능 추가/수정 후 UI나 비즈니스 로직에 영향은 없나요?
- [ ] PR 리뷰어가 중점적으로 확인하면 좋을 부분은?

## 🙏 기타 참고 사항

* ~로그아웃 했을 때도 모바일 환경에서 셀렉트 박스 하나 가운데로 정렬함.~ 로그아웃한 상태에서는 원래대로 왼쪽으로 정렬