### PR TITLE
답변 저장 로직 개선 및 알림(Alert) 추가

### DIFF
--- a/src/app/components/GithubLoginNotice.tsx
+++ b/src/app/components/GithubLoginNotice.tsx
@@ -1,0 +1,25 @@
+import { Button } from "@/components/ui/button";
+import { MailIcon } from "lucide-react";
+
+export default function GithubLoginNotice() {
+  return (
+    <div className="flex flex-col justify-center items-center h-screen gap-6">
+      <div className="flex flex-col items-center">
+        <MailIcon size={64} className="mb-3" />
+        <h3 className="txt-2xl-b">이메일을 공개해주세요!</h3>
+        <p>클릭 시 GitHub 프로필 설정으로 이동합니다.</p>
+        <p className="text-[var(--gray-02)]">
+          &#40;Public Profile &#45;&gt; Public email 설정&#41;
+        </p>
+      </div>
+
+      <Button
+        onClick={() => {
+          window.open("https://github.com/settings/profile", "_blank");
+        }}
+      >
+        이동하기
+      </Button>
+    </div>
+  );
+}

--- a/src/app/questions/[questionid]/componsts/Alert.tsx
+++ b/src/app/questions/[questionid]/componsts/Alert.tsx
@@ -6,15 +6,17 @@ import {
   AlertDialogHeader,
   AlertDialogTitle,
 } from "@/components/ui/alert-dialog";
+
 interface AlertProps {
+  type: string;
   text: string;
   showAlert: boolean;
   setShowAlert: (value: boolean) => void;
 }
-export default function Alert({ text, showAlert, setShowAlert }: AlertProps) {
+export default function Alert({ type, text, showAlert, setShowAlert }: AlertProps) {
   return (
     <AlertDialog open={showAlert} onOpenChange={setShowAlert}>
-      <AlertDialogContent className="w-[300px]">
+      <AlertDialogContent>
         <AlertDialogHeader className="mx-auto mb-4">
           <AlertDialogTitle>{text}</AlertDialogTitle>
         </AlertDialogHeader>

--- a/src/app/questions/[questionid]/componsts/Alert.tsx
+++ b/src/app/questions/[questionid]/componsts/Alert.tsx
@@ -37,10 +37,10 @@ export default function Alert({ showAlert, setShowAlert }: AlertProps) {
           <AlertDialogTitle>{showAlert.text}</AlertDialogTitle>
         </AlertDialogHeader>
         <AlertDialogFooter className="mx-auto flex">
-          <AlertDialogAction onClick={handleMoveToLogin}>
+          <AlertDialogAction onClick={handleMoveToLogin} className="w-[100px]">
             {isLogin ? "이동하기" : "확인"}
           </AlertDialogAction>
-          <AlertDialogCancel>닫기</AlertDialogCancel>
+          <AlertDialogCancel className="w-[100px]">닫기</AlertDialogCancel>
         </AlertDialogFooter>
       </AlertDialogContent>
     </AlertDialog>

--- a/src/app/questions/[questionid]/componsts/Alert.tsx
+++ b/src/app/questions/[questionid]/componsts/Alert.tsx
@@ -32,7 +32,7 @@ export default function Alert({ showAlert, setShowAlert }: AlertProps) {
       open={showAlert.action}
       onOpenChange={(open) => setShowAlert({ ...showAlert, action: open })}
     >
-      <AlertDialogContent>
+      <AlertDialogContent className="w-[300px]">
         <AlertDialogHeader className="mx-auto mb-4">
           <AlertDialogTitle>{showAlert.text}</AlertDialogTitle>
         </AlertDialogHeader>

--- a/src/app/questions/[questionid]/componsts/Alert.tsx
+++ b/src/app/questions/[questionid]/componsts/Alert.tsx
@@ -1,27 +1,43 @@
 import {
   AlertDialog,
-  AlertDialogCancel,
   AlertDialogContent,
   AlertDialogFooter,
   AlertDialogHeader,
   AlertDialogTitle,
+  AlertDialogAction,
 } from "@/components/ui/alert-dialog";
+import { useRouter } from "next/navigation";
 
-interface AlertProps {
+interface AlertType {
   type: string;
+  action: boolean;
   text: string;
-  showAlert: boolean;
-  setShowAlert: (value: boolean) => void;
 }
-export default function Alert({ type, text, showAlert, setShowAlert }: AlertProps) {
+interface AlertProps {
+  showAlert: AlertType;
+  setShowAlert: (value: AlertType) => void;
+}
+export default function Alert({ showAlert, setShowAlert }: AlertProps) {
+  const router = useRouter();
+  const handleMoveToLogin = () => {
+    if (showAlert.type === "login") {
+      router.push("/login");
+    }
+  };
+  const isLogin = showAlert.type === "login";
   return (
-    <AlertDialog open={showAlert} onOpenChange={setShowAlert}>
+    <AlertDialog
+      open={showAlert.action}
+      onOpenChange={(open) => setShowAlert({ ...showAlert, action: open })}
+    >
       <AlertDialogContent>
         <AlertDialogHeader className="mx-auto mb-4">
-          <AlertDialogTitle>{text}</AlertDialogTitle>
+          <AlertDialogTitle>{showAlert.text}</AlertDialogTitle>
         </AlertDialogHeader>
         <AlertDialogFooter className="mx-auto">
-          <AlertDialogCancel>확인</AlertDialogCancel>
+          <AlertDialogAction onClick={handleMoveToLogin}>
+            {isLogin ? "이동하기" : "확인"}
+          </AlertDialogAction>
         </AlertDialogFooter>
       </AlertDialogContent>
     </AlertDialog>

--- a/src/app/questions/[questionid]/componsts/Alert.tsx
+++ b/src/app/questions/[questionid]/componsts/Alert.tsx
@@ -5,7 +5,9 @@ import {
   AlertDialogHeader,
   AlertDialogTitle,
   AlertDialogAction,
+  AlertDialogCancel,
 } from "@/components/ui/alert-dialog";
+
 import { useRouter } from "next/navigation";
 
 interface AlertType {
@@ -34,10 +36,11 @@ export default function Alert({ showAlert, setShowAlert }: AlertProps) {
         <AlertDialogHeader className="mx-auto mb-4">
           <AlertDialogTitle>{showAlert.text}</AlertDialogTitle>
         </AlertDialogHeader>
-        <AlertDialogFooter className="mx-auto">
+        <AlertDialogFooter className="mx-auto flex">
           <AlertDialogAction onClick={handleMoveToLogin}>
             {isLogin ? "이동하기" : "확인"}
           </AlertDialogAction>
+          <AlertDialogCancel>닫기</AlertDialogCancel>
         </AlertDialogFooter>
       </AlertDialogContent>
     </AlertDialog>

--- a/src/app/questions/[questionid]/componsts/OtherUsersAnswer.tsx
+++ b/src/app/questions/[questionid]/componsts/OtherUsersAnswer.tsx
@@ -44,12 +44,13 @@ export default function OtherUsersAnswer({ questionId, userEmail, token }: Props
   }, [handleGetOtherAnswers]);
 
   const isContents = paginatedAnswers?.length > 0;
+
   return (
     <>
       <h3 className="txt-2xl-b pb-5">다른 사람 답변 확인하기</h3>
       <div
-        className={`grid grid-rows-auto gap-3 grid-cols-1 sm:grid-cols-2 ${
-          isContents ? "" : "grid-cols-1 mb-[100px]"
+        className={`grid gap-3 ${
+          isContents ? "grid-cols-1 sm:grid-cols-2" : "grid-cols-1 mb-[100px]"
         }`}
       >
         {questionAnswers.length > 0 ? (

--- a/src/app/questions/[questionid]/page.tsx
+++ b/src/app/questions/[questionid]/page.tsx
@@ -31,9 +31,7 @@ export default function AnswerFormPage() {
   const searchParams = useSearchParams();
   const user = useAuthStore((state) => state.user);
   const params = useParams();
-  const router = useRouter();
   const questionId = Number(params.questionid);
-  const [userEmail, setUserEmail] = useState<string | null>(user?.email);
   const [tab, setTab] = useState<string>("tab1");
   const [userAnswer, setUserAnswer] = useState("");
   const [isSubmitted, setIsSubmitted] = useState(false);
@@ -44,14 +42,13 @@ export default function AnswerFormPage() {
   const token: string | null = useAuthStore((state) => state.token);
   const avatar = user?.avatarUrl;
   const nickName = user?.nickname;
-  const { localToken, localEmail, isLogin } = handleCheckUser();
-
+  const userEmail = searchParams.get("userId");
+  const { localEmail, isLogin } = handleCheckUser();
   const isMatchCurrentLoginUser = token !== null && localEmail === userEmail;
 
   //깃허브 유저 확인
   const checkGithubUser = token !== null && userEmail == null;
   // 초기 들어왔을 때 이전에 작성한 답변이 있으면 불러오기
-
   const handleGetQuestion = useCallback(async () => {
     try {
       const response = await fetch(

--- a/src/app/questions/[questionid]/page.tsx
+++ b/src/app/questions/[questionid]/page.tsx
@@ -44,7 +44,9 @@ export default function AnswerFormPage() {
   const userEmail = searchParams.get("userId");
   const { localEmail, isLogin } = handleCheckUser();
   const isMatchCurrentLoginUser = token !== null && localEmail === userEmail;
-
+  if (isEditing) {
+    answerRef.current?.focus();
+  }
   //깃허브 유저 확인
   const checkGithubUser = token !== null && userEmail == null;
   // 초기 들어왔을 때 이전에 작성한 답변이 있으면 불러오기
@@ -85,11 +87,19 @@ export default function AnswerFormPage() {
     }
   }, [questionData]);
 
-  if (isEditing) {
-    answerRef.current?.focus();
-  }
+  useEffect(() => {
+    if (isEditing) {
+      answerRef.current?.focus();
+    }
+  }, [isEditing]);
 
-  //답변 저장, 수정
+  useEffect(() => {
+    if (!showAlert.action) {
+      setIsEditing(true);
+    }
+  }, [showAlert.action]);
+
+  console.log(isEditing, "isEditing");
   const handleSaveAnswer = async (action: AnswerAction) => {
     if (!isLogin) {
       return setShowAlert((prev) => ({

--- a/src/app/questions/[questionid]/page.tsx
+++ b/src/app/questions/[questionid]/page.tsx
@@ -12,6 +12,7 @@ import { toast } from "sonner";
 import OtherUsersAnswer from "./componsts/OtherUsersAnswer";
 import Loader from "@/components/common/Loader";
 import Alert from "./componsts/Alert";
+import GithubLoginNotice from "@/app/components/GithubLoginNotice";
 
 type AnswerAction = "create" | "update";
 interface QuestionResponse {
@@ -45,7 +46,7 @@ export default function AnswerFormPage() {
   const { localToken, localEmail } = handleCheckUser();
   const isMatchCurrentLoginUser =
     token !== null && token === localToken && localEmail === userEmail;
-
+  const checkGithubUser = token !== null && userEmail == null;
   // 초기 들어왔을 때 이전에 작성한 답변이 있으면 불러오기
   //userId 없을 수 있음, questionId 필수
   const handleGetQuestion = useCallback(async () => {
@@ -75,7 +76,8 @@ export default function AnswerFormPage() {
   useEffect(() => {
     handleGetQuestion();
   }, [handleGetQuestion]);
-
+  console.log(userEmail, "userEmailuserEmail");
+  console.log(token, "token");
   useEffect(() => {
     if (!questionData) return;
     if (questionData?.answer !== "") {
@@ -98,6 +100,16 @@ export default function AnswerFormPage() {
         text: "로그인이 필요합니다",
       }));
     }
+
+    if (checkGithubUser) {
+      return setShowAlert((prev) => ({
+        ...prev,
+        type: "github",
+        action: true,
+        text: "깃허브 이메일 공개가 필요합니다",
+      }));
+    }
+
     if (userAnswer.trim().length === 0) {
       return setShowAlert((prev) => ({
         ...prev,

--- a/src/app/questions/[questionid]/page.tsx
+++ b/src/app/questions/[questionid]/page.tsx
@@ -99,7 +99,6 @@ export default function AnswerFormPage() {
     }
   }, [showAlert.action]);
 
-  console.log(isEditing, "isEditing");
   const handleSaveAnswer = async (action: AnswerAction) => {
     if (!isLogin) {
       return setShowAlert((prev) => ({

--- a/src/app/questions/[questionid]/page.tsx
+++ b/src/app/questions/[questionid]/page.tsx
@@ -92,12 +92,10 @@ export default function AnswerFormPage() {
   //답변 저장, 수정
   const handleSaveAnswer = async (action: AnswerAction) => {
     if (!isMatchCurrentLoginUser) {
-      router.replace("/404");
+      return setShowAlert(true);
     }
     if (userAnswer.trim().length === 0) {
-      setShowAlert(true);
-
-      return;
+      return setShowAlert(true);
     }
 
     const method = action === "create" ? "POST" : "PUT";
@@ -160,7 +158,12 @@ export default function AnswerFormPage() {
   return (
     <>
       {showAlert && (
-        <Alert text="내용을 입력해주세요" showAlert={showAlert} setShowAlert={setShowAlert} />
+        <Alert
+          type="content"
+          text="내용을 입력해주세요"
+          showAlert={showAlert}
+          setShowAlert={setShowAlert}
+        />
       )}
       <div className="container mx-auto pt-[40px]">
         <QusetionHeader

--- a/src/app/questions/[questionid]/page.tsx
+++ b/src/app/questions/[questionid]/page.tsx
@@ -29,7 +29,6 @@ interface QuestionResponse {
 export default function AnswerFormPage() {
   const searchParams = useSearchParams();
   const params = useParams();
-  const router = useRouter();
   const questionId = Number(params.questionid);
   const userEmail: string | null = searchParams.get("userId");
   const [tab, setTab] = useState<string>("tab1");
@@ -37,7 +36,7 @@ export default function AnswerFormPage() {
   const [isSubmitted, setIsSubmitted] = useState(false);
   const [isEditing, setIsEditing] = useState(true);
   const [questionData, setQuestionData] = useState<QuestionResponse | null>(null);
-  const [showAlert, setShowAlert] = useState(false);
+  const [showAlert, setShowAlert] = useState({ type: "", action: false, text: "" });
   const answerRef = useRef<HTMLTextAreaElement>(null);
   const token: string | null = useAuthStore((state) => state.token);
   const user = useAuthStore((state) => state.user);
@@ -92,10 +91,20 @@ export default function AnswerFormPage() {
   //답변 저장, 수정
   const handleSaveAnswer = async (action: AnswerAction) => {
     if (!isMatchCurrentLoginUser) {
-      return setShowAlert(true);
+      return setShowAlert((prev) => ({
+        ...prev,
+        type: "login",
+        action: true,
+        text: "로그인이 필요합니다",
+      }));
     }
     if (userAnswer.trim().length === 0) {
-      return setShowAlert(true);
+      return setShowAlert((prev) => ({
+        ...prev,
+        type: "content",
+        action: true,
+        text: "내용을 입력해주세요",
+      }));
     }
 
     const method = action === "create" ? "POST" : "PUT";
@@ -157,14 +166,7 @@ export default function AnswerFormPage() {
   const { content, solution, isBookmarked, categoryName } = questionData;
   return (
     <>
-      {showAlert && (
-        <Alert
-          type="content"
-          text="내용을 입력해주세요"
-          showAlert={showAlert}
-          setShowAlert={setShowAlert}
-        />
-      )}
+      {showAlert && <Alert showAlert={showAlert} setShowAlert={setShowAlert} />}
       <div className="container mx-auto pt-[40px]">
         <QusetionHeader
           content={content}

--- a/src/app/questions/[questionid]/page.tsx
+++ b/src/app/questions/[questionid]/page.tsx
@@ -1,7 +1,6 @@
 "use client";
 import { useCallback, useEffect, useRef, useState } from "react";
 import { useParams, useSearchParams } from "next/navigation";
-import { useRouter } from "next/navigation";
 import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
 import { Button } from "@/components/ui/button";
 import { useAuthStore } from "@/store/useAuthStore";

--- a/src/app/questions/[questionid]/page.tsx
+++ b/src/app/questions/[questionid]/page.tsx
@@ -7,7 +7,7 @@ import QusetionHeader from "./componsts/QusetionHeader";
 import QuestionSolution from "@/app/questions/[questionid]/componsts/QuestionSolution";
 import { useParams, useSearchParams } from "next/navigation";
 import { handleCheckUser } from "@/utils/handleCheckUser";
-import { useRouter } from "next/navigation";
+
 import { toast } from "sonner";
 import OtherUsersAnswer from "./componsts/OtherUsersAnswer";
 import Loader from "@/components/common/Loader";

--- a/src/application/usecase/answer/CreateAnswerUsecase.ts
+++ b/src/application/usecase/answer/CreateAnswerUsecase.ts
@@ -7,6 +7,7 @@ export class CreateAnswerUsecase {
   //답변을 만들기 위한 입력 데이터 객체 (DTO)         //리턴값
   async execute(createDto: CreateAnswerDto): Promise<Answer> {
     const { userId, questionId, content, userName, avatarUrl } = createDto;
+    console.log("userId", userId);
     if (!createDto.userId) {
       //로그인 페이지로 이동 추가
       throw new Error("회원이 아닙니다.");

--- a/src/components/common/MailAlert.tsx
+++ b/src/components/common/MailAlert.tsx
@@ -8,9 +8,11 @@ import {
   AlertDialogTitle,
   AlertDialogAction,
   AlertDialogDescription,
+  AlertDialogFooter,
 } from "@/components/ui/alert-dialog";
 import { useProfileStore } from "@/store/useProfileStore";
 import { Mail } from "lucide-react";
+import { AlertDialogCancel } from "@radix-ui/react-alert-dialog";
 
 export default function MailAlertButton() {
   const { showLoginAlert, setShowLoginAlert } = useProfileStore();

--- a/src/components/common/MailAlert.tsx
+++ b/src/components/common/MailAlert.tsx
@@ -8,11 +8,9 @@ import {
   AlertDialogTitle,
   AlertDialogAction,
   AlertDialogDescription,
-  AlertDialogFooter,
 } from "@/components/ui/alert-dialog";
 import { useProfileStore } from "@/store/useProfileStore";
 import { Mail } from "lucide-react";
-import { AlertDialogCancel } from "@radix-ui/react-alert-dialog";
 
 export default function MailAlertButton() {
   const { showLoginAlert, setShowLoginAlert } = useProfileStore();
@@ -40,6 +38,7 @@ export default function MailAlertButton() {
               setShowLoginAlert(false);
               router.push("/login");
             }}
+            className="w-2/6 bg-[var(--blue-02)] border-none"
           >
             이동하기
           </AlertDialogAction>

--- a/src/components/common/MailAlert.tsx
+++ b/src/components/common/MailAlert.tsx
@@ -38,7 +38,6 @@ export default function MailAlertButton() {
               setShowLoginAlert(false);
               router.push("/login");
             }}
-            className="w-2/6 bg-[var(--blue-02)] border-none"
           >
             이동하기
           </AlertDialogAction>

--- a/src/components/ui/alert-dialog.tsx
+++ b/src/components/ui/alert-dialog.tsx
@@ -46,7 +46,7 @@ function AlertDialogContent({
       <AlertDialogPrimitive.Content
         data-slot="alert-dialog-content"
         className={cn(
-          "bg-background data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 fixed top-[50%] left-[50%] z-50 grid w-full max-w-[calc(100%-2rem)] translate-x-[-50%] translate-y-[-50%] gap-4 rounded-lg border p-6 shadow-lg duration-200 sm:max-w-lg",
+          "bg-background data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 fixed top-[50%] left-[50%] z-50 grid min-w-[300px] max-w-[calc(100%-2rem)] translate-x-[-50%] translate-y-[-50%] gap-4 rounded-lg border p-6 shadow-lg duration-200 sm:max-w-lg",
           className
         )}
         {...props}
@@ -82,7 +82,7 @@ function AlertDialogTitle({
   return (
     <AlertDialogPrimitive.Title
       data-slot="alert-dialog-title"
-      className={cn("text-2xl font-semibold", className)}
+      className={cn("text-xl font-semibold", className)}
       {...props}
     />
   );
@@ -95,7 +95,7 @@ function AlertDialogDescription({
   return (
     <AlertDialogPrimitive.Description
       data-slot="alert-dialog-description"
-      className={cn("text-muted-foreground text-md", className)}
+      className={cn("text-muted-foreground text-base", className)}
       {...props}
     />
   );

--- a/src/components/ui/alert-dialog.tsx
+++ b/src/components/ui/alert-dialog.tsx
@@ -1,31 +1,23 @@
-"use client"
+"use client";
 
-import * as React from "react"
-import * as AlertDialogPrimitive from "@radix-ui/react-alert-dialog"
+import * as React from "react";
+import * as AlertDialogPrimitive from "@radix-ui/react-alert-dialog";
 
-import { cn } from "@/lib/utils"
-import { buttonVariants } from "@/components/ui/button"
+import { cn } from "@/lib/utils";
+import { buttonVariants } from "@/components/ui/button";
 
-function AlertDialog({
-  ...props
-}: React.ComponentProps<typeof AlertDialogPrimitive.Root>) {
-  return <AlertDialogPrimitive.Root data-slot="alert-dialog" {...props} />
+function AlertDialog({ ...props }: React.ComponentProps<typeof AlertDialogPrimitive.Root>) {
+  return <AlertDialogPrimitive.Root data-slot="alert-dialog" {...props} />;
 }
 
 function AlertDialogTrigger({
   ...props
 }: React.ComponentProps<typeof AlertDialogPrimitive.Trigger>) {
-  return (
-    <AlertDialogPrimitive.Trigger data-slot="alert-dialog-trigger" {...props} />
-  )
+  return <AlertDialogPrimitive.Trigger data-slot="alert-dialog-trigger" {...props} />;
 }
 
-function AlertDialogPortal({
-  ...props
-}: React.ComponentProps<typeof AlertDialogPrimitive.Portal>) {
-  return (
-    <AlertDialogPrimitive.Portal data-slot="alert-dialog-portal" {...props} />
-  )
+function AlertDialogPortal({ ...props }: React.ComponentProps<typeof AlertDialogPrimitive.Portal>) {
+  return <AlertDialogPrimitive.Portal data-slot="alert-dialog-portal" {...props} />;
 }
 
 function AlertDialogOverlay({
@@ -41,7 +33,7 @@ function AlertDialogOverlay({
       )}
       {...props}
     />
-  )
+  );
 }
 
 function AlertDialogContent({
@@ -60,36 +52,27 @@ function AlertDialogContent({
         {...props}
       />
     </AlertDialogPortal>
-  )
+  );
 }
 
-function AlertDialogHeader({
-  className,
-  ...props
-}: React.ComponentProps<"div">) {
+function AlertDialogHeader({ className, ...props }: React.ComponentProps<"div">) {
   return (
     <div
       data-slot="alert-dialog-header"
       className={cn("flex flex-col gap-2 text-center sm:text-left", className)}
       {...props}
     />
-  )
+  );
 }
 
-function AlertDialogFooter({
-  className,
-  ...props
-}: React.ComponentProps<"div">) {
+function AlertDialogFooter({ className, ...props }: React.ComponentProps<"div">) {
   return (
     <div
       data-slot="alert-dialog-footer"
-      className={cn(
-        "flex flex-col-reverse gap-2 sm:flex-row sm:justify-end",
-        className
-      )}
+      className={cn("flex flex-col-reverse gap-2 sm:flex-row sm:justify-end", className)}
       {...props}
     />
-  )
+  );
 }
 
 function AlertDialogTitle({
@@ -99,10 +82,10 @@ function AlertDialogTitle({
   return (
     <AlertDialogPrimitive.Title
       data-slot="alert-dialog-title"
-      className={cn("text-lg font-semibold", className)}
+      className={cn("text-2xl font-semibold", className)}
       {...props}
     />
-  )
+  );
 }
 
 function AlertDialogDescription({
@@ -112,22 +95,17 @@ function AlertDialogDescription({
   return (
     <AlertDialogPrimitive.Description
       data-slot="alert-dialog-description"
-      className={cn("text-muted-foreground text-sm", className)}
+      className={cn("text-muted-foreground text-md", className)}
       {...props}
     />
-  )
+  );
 }
 
 function AlertDialogAction({
   className,
   ...props
 }: React.ComponentProps<typeof AlertDialogPrimitive.Action>) {
-  return (
-    <AlertDialogPrimitive.Action
-      className={cn(buttonVariants(), className)}
-      {...props}
-    />
-  )
+  return <AlertDialogPrimitive.Action className={cn(buttonVariants(), className)} {...props} />;
 }
 
 function AlertDialogCancel({
@@ -139,7 +117,7 @@ function AlertDialogCancel({
       className={cn(buttonVariants({ variant: "outline" }), className)}
       {...props}
     />
-  )
+  );
 }
 
 export {
@@ -154,4 +132,4 @@ export {
   AlertDialogDescription,
   AlertDialogAction,
   AlertDialogCancel,
-}
+};

--- a/src/components/ui/alert-dialog.tsx
+++ b/src/components/ui/alert-dialog.tsx
@@ -46,7 +46,7 @@ function AlertDialogContent({
       <AlertDialogPrimitive.Content
         data-slot="alert-dialog-content"
         className={cn(
-          "bg-background data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 fixed top-[50%] left-[50%] z-50 grid min-w-[300px] max-w-[calc(100%-2rem)] translate-x-[-50%] translate-y-[-50%] gap-4 rounded-lg border p-6 shadow-lg duration-200 sm:max-w-lg",
+          "bg-background data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 fixed top-[50%] left-[50%] z-50 grid w-full max-w-[calc(100%-2rem)] translate-x-[-50%] translate-y-[-50%] gap-4 rounded-lg border p-6 shadow-lg duration-200 sm:max-w-lg",
           className
         )}
         {...props}
@@ -82,7 +82,7 @@ function AlertDialogTitle({
   return (
     <AlertDialogPrimitive.Title
       data-slot="alert-dialog-title"
-      className={cn("text-xl font-semibold", className)}
+      className={cn("text-lg font-semibold", className)}
       {...props}
     />
   );
@@ -95,7 +95,7 @@ function AlertDialogDescription({
   return (
     <AlertDialogPrimitive.Description
       data-slot="alert-dialog-description"
-      className={cn("text-muted-foreground text-base", className)}
+      className={cn("text-muted-foreground text-sm", className)}
       {...props}
     />
   );
@@ -114,7 +114,7 @@ function AlertDialogCancel({
 }: React.ComponentProps<typeof AlertDialogPrimitive.Cancel>) {
   return (
     <AlertDialogPrimitive.Cancel
-      className={cn(buttonVariants({ variant: "outline" }), className)}
+      className={cn(buttonVariants({ variant: "gray" }), className)}
       {...props}
     />
   );

--- a/src/utils/handleCheckUser.ts
+++ b/src/utils/handleCheckUser.ts
@@ -1,6 +1,7 @@
 type LocalType = {
   localToken: string | null;
   localEmail: string | null;
+  isLogin: boolean;
 };
 export function handleCheckUser(): LocalType {
   const userLocalData = localStorage.getItem("auth-storage");
@@ -8,9 +9,11 @@ export function handleCheckUser(): LocalType {
     return {
       localToken: null,
       localEmail: null,
+      isLogin: false,
     };
   const parsedData = JSON.parse(userLocalData);
+  const isLogin = parsedData?.state?.isLoggedIn;
   const localToken = parsedData?.state?.token || null;
   const localEmail = parsedData?.state?.user?.email || null;
-  return { localToken, localEmail };
+  return { localToken, localEmail, isLogin };
 }


### PR DESCRIPTION
## ✨ 작업 개요



## ✅ 상세 내용

- 답변 저장(handleSaveAnswer) 로직에 조건별 알림(Alert) 추가
  - 로그인하지 않은 경우: "로그인이 필요합니다" 알림 표시, 로그인 페이지로 이동 안내
  - 깃허브 연동 사용자(GitHub 소셜 로그인)일 때 이메일 공개 필요 알림 표시
  - 답변 내용이 비어있을 때: "내용을 입력해주세요" 알림 표시
- showAlert 상태에 type, action, text 전달하여 상황에 따라 분기 처리

<img width="1728" alt="스크린샷 2025-04-27 오후 6 38 46" src="https://github.com/user-attachments/assets/3fc6fdfa-4949-4d6b-8b2b-d546ecdb6c69" />

<img width="1728" alt="스크린샷 2025-04-27 오후 6 38 30" src="https://github.com/user-attachments/assets/cfe697e5-92ab-4687-b88e-2fc5bff5aec8" />


## 🧪 확인 사항

- [ ] 정상적으로 동작하는지 직접 테스트해봤나요?
- [ ] 기능 추가/수정 후 UI나 비즈니스 로직에 영향은 없나요?
- [ ] PR 리뷰어가 중점적으로 확인하면 좋을 부분은?

## 🙏 기타 참고 사항

사용자가 url을 직접 조작했을 때 변경된 url 값을 받아올 수 있는 방법이 정말 없는걸까 .. . .. . . ..
