### PR TITLE
구독 메일 발송 시 연동링크 수정

### DIFF
--- a/src/lib/mail/sendMail.js
+++ b/src/lib/mail/sendMail.js
@@ -74,7 +74,7 @@ async function sendDailyQuestionMail() {
   const recipients = await getSubscribedEmails();
 
   const questionId = (category - 1) * 10 + questionNum;
-  const linkUrl = `http://localhost:3000/questions/${questionId}`;
+  const linkUrl = `https://lego-mail.vercel.app/questions/${questionId}`;
 
   const html = createTemplate(marked.parse(body), linkUrl);
 


### PR DESCRIPTION
## ✨ 작업 개요

localhost로 설정되어있던 구독 메일 버튼링크를 배포 링크로 수정했습니다.

## ✅ 상세 내용

- 위 내용과 같습니다.

## 📸 스크린샷 (선택)

## 🧪 확인 사항

- [ ] 정상적으로 동작하는지 직접 테스트해봤나요?
- [ ] 기능 추가/수정 후 UI나 비즈니스 로직에 영향은 없나요?
- [ ] PR 리뷰어가 중점적으로 확인하면 좋을 부분은?

## 🙏 기타 참고 사항
