### PR TITLE
배너 이미지 데탑 크기 수정

### DIFF
--- a/src/app/questions/page.tsx
+++ b/src/app/questions/page.tsx
@@ -239,13 +239,13 @@ export default function QuestionListPage() {
   const pagedQuestions = visibleQuestions.slice(startIdx, endIdx);
   return (
     <div className="w-full container mx-auto pt-[40px]">
-      <div className="relative w-full max-w-[948px] h-[115px] mb-6 overflow-hidden md:h-[115px] sm:h-[80px]">
+      <div className="relative w-full h-[115px] mb-6 overflow-hidden md:h-[115px] sm:h-[80px]">
         <Image
           src="/assets/images/banner.svg"
           alt="배너 이미지"
           fill
           priority
-          sizes="(max-width: 768px) 100vw, 948px"
+          sizes="(max-width: 768px) 100vw, 1080px"
           className="object-cover rounded-md"
         />
       </div>


### PR DESCRIPTION
## ✨ 작업 개요

* 배너 이미지 데탑 크기 수정

## ✅ 상세 내용

- [ ] 배너 이미지 크기가 948로 되어있던 코드 수정

## 📸 스크린샷 (선택)

## 🧪 확인 사항

- [ ] 정상적으로 동작하는지 직접 테스트해봤나요?
- [ ] 기능 추가/수정 후 UI나 비즈니스 로직에 영향은 없나요?
- [ ] PR 리뷰어가 중점적으로 확인하면 좋을 부분은?

## 🙏 기타 참고 사항
